### PR TITLE
Fixed error causing dead on-board batteries

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -162,8 +162,8 @@
                 <label for="evHistory" class="translate">Receive Daily drive History (EV cars only, needs 3 request per day)</label>
             </div>
 			<div class="col s6 input-field">
-                <input type="checkbox" class="value" id="stopRefreshUnder50" />
-                <label for="stopRefreshUnder50" class="translate">Stop refresh if 12V battery is under 50%</label>
+                <input type="checkbox" class="value" id="protectAgainstDeepDischarge" />
+                <label for="protectAgainstDeepDischarge" class="translate">Stop refresh if 12V battery is under 10.5 V to protect against irreversible damage</label>
             </div>
 
 		<div class="col s6 input-field">

--- a/admin/words.js
+++ b/admin/words.js
@@ -146,17 +146,17 @@ systemDictionary = {
         'pl': 'Otrzymuj historię dziennych przejazdów (tylko samochody elektryczne, wymaga 3 żądań dziennie)',
         'zh-cn': '接收每日驾驶历史记录（仅限电动汽车，每天需要 3 个请求）'
     },
-    'Stop refresh if 12V battery is under 50%': {
-        'en': 'Stop refresh if 12V battery is under 50%',
-        'de': 'Aktualisierung stoppen, wenn die 12-V-Batterie unter 50% ist',
-        'ru': 'Остановите обновление, если батарея 12 В менее 50%',
-        'pt': 'Pare a atualização se a bateria de 12 V estiver abaixo de 50%',
-        'nl': 'Stop met vernieuwen als de 12V-batterij minder dan 50% is',
-        'fr': 'Arrêtez le rafraîchissement si la batterie 12V est inférieure à 50%',
-        'it': "Interrompi l'aggiornamento se la batteria da 12 V è inferiore al 50%",
-        'es': 'Detenga la actualización si la batería de 12 V está por debajo del 50%',
-        'pl': 'Zatrzymaj odświeżanie, jeśli poziom naładowania akumulatora 12 V spadnie poniżej 50%',
-        'zh-cn': '如果 12V 电池电量低于 50%，则停止刷新'
+    'Stop refresh if 12V battery is under 10.5 V to protect against irreversible damage': {
+        'en': 'Stop refresh if 12V battery is under 10.5 V to protect against irreversible damage',
+        'de': 'Aktualisierung stoppen, wenn die 12-V-Batterie unter 10,5 V fällt, um irreversible Schäden zu vermeiden',
+        'ru': 'Остановите обновление, если напряжение батареи 12 В ниже 10,5 В, для защиты от необратимого повреждения',
+        'pt': 'Parar a actualização se a bateria de 12V for inferior a 10,5 V para proteger contra danos irreversíveis',
+        'nl': 'Stop verversen als 12V batterij onder 10,5 V is om te beschermen tegen onomkeerbare schade',
+        'fr': 'Arrêtez le rafraîchissement si la batterie 12V est inférieure à 10,5 V pour éviter tout dommage irréversible.',
+        'it': "Interrompe l'aggiornamento se la batteria da 12 V è inferiore a 10,5 V per evitare danni irreversibili.",
+        'es': 'Detiene la actualización si la batería de 12 V está por debajo de 10,5 V para evitar daños irreversibles.',
+        'pl': 'Zatrzymanie odświeżania, jeśli napięcie akumulatora 12V jest niższe niż 10,5 V, aby chronić przed nieodwracalnym uszkodzeniem',
+        'zh-cn': '如果12V电池低于10.5V，则停止刷新，以防止不可逆的损坏。'
     },
     'ErrorConter':{
         'en': 'Error Counter for restart the adapter after fail connection',

--- a/io-package.json
+++ b/io-package.json
@@ -250,7 +250,7 @@
     "brand": "K",
     "request": 100,
     "evHistory": true,
-    "stopRefreshUnder50": true,
+    "protectAgainstDeepDischarge": true,
     "errorCounter": 5,
     "language": "DE"
   },

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ const bluelinky = require('bluelinky');
 const Json2iob = require('./lib/json2iob');
 
 const adapterIntervals = {}; //halten von allen Intervallen
-let request_count = 100; //max api request per Day
+let request_count = 48; // halbstündig sollte als Standardeinstellung reichen (zu häufige Abfragen entleeren die Batterie spürbar)
 let client;
 
 let slow_charging;
@@ -242,10 +242,10 @@ class Bluelink extends utils.Adapter {
             await this.setStateAsync(`${vin}.lastInfoUpdate`, Number(Date.now()), true);
 
             this.log.debug('Read new status from api for ' + vin);
-            if (this.batteryState12V[vin] && this.batteryState12V[vin] < 50) {
-                this.log.warn('12V Battery state is low: ' + this.batteryState12V[vin] + '%');
-                if (this.config.stopRefreshUnder50 && !force) {
-                    this.log.warn('Auto Refresh is disabled, use force refresh to enable refresh again');
+            if (this.batteryState12V[vin] && this.batteryState12V[vin] < 88) {
+                this.log.warn('12V Battery state is low: ' + this.batteryState12V[vin] + '%. Recharge to prevent damage!');
+                if (this.config.protectAgainstDeepDischarge && !force) {
+                    this.log.warn('Auto Refresh is disabled, only use force refresh to reenable refresh if you are willing to risk your battery');
                     continue;
                 }
             }


### PR DESCRIPTION
The previous measures were allowing the complete discharge of onboard batteries through unnecessarily high refresh counts (should be limited even further in the future) and a misunderstanding in behavior of lead batteries. 
Explanation: 50% of measured voltage does not equal to 50% of remaining capacity. Instead, it means a dead battery. 10.5V (around 88%) is the minimum a 12V lead battery should be discharged to. This setting already destroyed two onboard batteries before I discovered it.  