### PR TITLE
fix: call vehicle.location() separately when fullStatus has no Location field

### DIFF
--- a/main.js
+++ b/main.js
@@ -437,6 +437,16 @@ class Bluelink extends utils.Adapter {
                     // location sonderlocke
                     if (newStatus.hasOwnProperty('Location')) {   // beniziner haben anscheinenden keine location
                     	await tools.setLocation(this, vin, newStatus.Location.GeoCoord.Latitude, newStatus.Location.GeoCoord.Longitude, newStatus.Location.Speed.Value);
+                    } else {
+                        // new API format (Body structure): Location not in fullStatus – separate call
+                        try {
+                            const loc = await vehicle.location();
+                            if (loc && loc.latitude != null && loc.longitude != null) {
+                                await tools.setLocation(this, vin, loc.latitude, loc.longitude, loc.speed?.value ?? 0);
+                            }
+                        } catch (locErr) {
+                            this.log.warn(`vehicle.location() failed: ${locErr}`);
+                        }
                     }
                 }
 
@@ -467,6 +477,16 @@ class Bluelink extends utils.Adapter {
                         // location sonderlocke
                         if (newStatus.hasOwnProperty('Location')) {   // beniziner haben anscheinenden keine location
                         	await tools.setLocation(this, vin, newStatus.Location.GeoCoord.Latitude, newStatus.Location.GeoCoord.Longitude, newStatus.Location.Speed.Value);
+                        } else {
+                            // new API format: separate location call
+                            try {
+                                const loc = await vehicle.location();
+                                if (loc && loc.latitude != null && loc.longitude != null) {
+                                    await tools.setLocation(this, vin, loc.latitude, loc.longitude, loc.speed?.value ?? 0);
+                                }
+                            } catch (locErr) {
+                                this.log.warn(`vehicle.location() failed: ${locErr}`);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- After the Hyundai Bluelink → myHyundai App migration (March 2026), `fullStatus()` returns a new `Body`-structured response that no longer contains GPS coordinates at the top level
- The adapter checked `newStatus.hasOwnProperty('Location')` — this is always `false` with the new API format, so GPS states were never updated
- The bluelinky library already has a dedicated `vehicle.location()` method that calls the `/api/v2/spa/vehicles/{id}/location` endpoint separately
- This PR adds a fallback to that dedicated call in both the `fullStatus` path and the `status` fallback path

## Test plan

- [ ] Adapter runs without errors on new CCU2 API (`Version: "CCU2026..."`)
- [ ] `vehicleLocation.lat` / `.lon` / `.speed` / `.position_url` / `.position_text` are populated after update cycle
- [ ] No regression for vehicles that still return `Location` in `fullStatus()` (old API format)
- [ ] `vehicle.location()` errors are caught and logged as warn, not crashing the update cycle

## Background

Confirmed working on a Hyundai Tucson with the new myHyundai API. The issue is also reported by multiple users in the ioBroker forum after Hyundai dropped the old Bluelink App at end of March 2026.