### PR TITLE
fix: CCI token restart-loop regression from #354 (live-confirmed, urgent)

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -18,5 +18,5 @@
     "only for PHEV": "nur für PHEV",
     "Token-documentation": "Token-Dokumentation",
     "Password": "Passwort (Konto-Passwort)",
-    "Token valid until (auto-managed)": "Refresh-Token gültig bis (automatisch verwaltet)"
+    "Last successful login (auto-managed)": "Letzte erfolgreiche Anmeldung (automatisch verwaltet)"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -18,5 +18,5 @@
     "only for PHEV": "only for PHEV",
     "Token-documentation": "Token documentation",
     "Password": "Password (account password)",
-    "Token valid until (auto-managed)": "Refresh token valid until (auto-managed)"
+    "Last successful login (auto-managed)": "Last successful login (auto-managed)"
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -17,5 +17,5 @@
     "only for PHEV": "solo para PHEV",
     "Token-documentation": "Documentación del token",
     "Password": "Contraseña (contraseña de cuenta)",
-    "Token valid until (auto-managed)": "Token de actualización válido hasta (gestionado automáticamente)"
+    "Last successful login (auto-managed)": "Último inicio de sesión correcto (gestionado automáticamente)"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -17,5 +17,5 @@
     "only for PHEV": "seulement pour PHEV",
     "Token-documentation": "Documentation relative aux jetons",
     "Password": "Mot de passe (mot de passe du compte)",
-    "Token valid until (auto-managed)": "Jeton d'actualisation valide jusqu'au (géré automatiquement)"
+    "Last successful login (auto-managed)": "Dernière connexion réussie (gérée automatiquement)"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -17,5 +17,5 @@
     "only for PHEV": "solo per PHEV",
     "Token-documentation": "Documentazione del token",
     "Password": "Password (password dell'account)",
-    "Token valid until (auto-managed)": "Token di aggiornamento valido fino a (gestito automaticamente)"
+    "Last successful login (auto-managed)": "Ultimo accesso riuscito (gestito automaticamente)"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -17,5 +17,5 @@
     "only for PHEV": "alleen voor PHEV",
     "Token-documentation": "Tokendocumentatie",
     "Password": "Wachtwoord (accountwachtwoord)",
-    "Token valid until (auto-managed)": "Vernieuwingstoken geldig tot (automatisch beheerd)"
+    "Last successful login (auto-managed)": "Laatste geslaagde aanmelding (automatisch beheerd)"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -17,5 +17,5 @@
     "only for PHEV": "tylko dla PHEV",
     "Token-documentation": "Dokumentacja tokena",
     "Password": "Hasło (hasło do konta)",
-    "Token valid until (auto-managed)": "Token odświeżający ważny do (zarządzany automatycznie)"
+    "Last successful login (auto-managed)": "Ostatnie udane logowanie (zarządzane automatycznie)"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -18,5 +18,5 @@
     "only for PHEV": "apenas para PHEV",
     "Token-documentation": "Documentação do token",
     "Password": "Senha (senha da conta)",
-    "Token valid until (auto-managed)": "Token de atualização válido até (gerenciado automaticamente)"
+    "Last successful login (auto-managed)": "Último login bem-sucedido (gerenciado automaticamente)"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -18,5 +18,5 @@
     "only for PHEV": "только для PHEV",
     "Token-documentation": "Документация по токенам",
     "Password": "Пароль (пароль учётной записи)",
-    "Token valid until (auto-managed)": "Токен обновления действителен до (управляется автоматически)"
+    "Last successful login (auto-managed)": "Последний успешный вход (управляется автоматически)"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -17,5 +17,5 @@
     "only for PHEV": "тільки для PHEV",
     "Token-documentation": "Документація токена",
     "Password": "Пароль (пароль облікового запису)",
-    "Token valid until (auto-managed)": "Токен оновлення дійсний до (керується автоматично)"
+    "Last successful login (auto-managed)": "Останній успішний вхід (керується автоматично)"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -18,5 +18,5 @@
     "only for PHEV": "?????????????(PHEV)",
     "Token-documentation": "令牌文档",
     "Password": "密码（账户密码）",
-    "Token valid until (auto-managed)": "刷新令牌有效期至（自动管理）"
+    "Last successful login (auto-managed)": "上次成功登录（自动管理）"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -132,9 +132,9 @@
             "lg": 3,
             "xl": 3
         },
-        "tokenExpiry": {
+        "lastLoginDisplay": {
             "type": "text",
-            "label": "Token valid until (auto-managed)",
+            "label": "Last successful login (auto-managed)",
             "disabled": "true",
             "xs": 12,
             "sm": 12,

--- a/io-package.json
+++ b/io-package.json
@@ -185,6 +185,7 @@
     "tokenType": "",
     "cciTokenSet": "",
     "lastTokenSaveAt": 0,
+    "lastLoginDisplay": "",
     "brand": "kia",
     "request": 100,
     "evHistory": true,

--- a/main.js
+++ b/main.js
@@ -141,6 +141,17 @@ class Bluelink extends utils.Adapter {
             native: {},
         });
 
+        // One-time backfill: older installs already have a real lastTokenSaveAt but never
+        // had lastLoginDisplay set (field didn't exist yet) - without this it'd stay blank
+        // in the admin UI until the next actual token save, even though a login did happen.
+        if (!this.config.lastLoginDisplay && this.config.lastTokenSaveAt) {
+            const adapterObj = await this.getForeignObjectAsync(`system.adapter.${this.namespace}`);
+            if (adapterObj) {
+                adapterObj.native.lastLoginDisplay = new Date(Number(this.config.lastTokenSaveAt)).toISOString();
+                await this.setForeignObjectAsync(`system.adapter.${this.namespace}`, adapterObj);
+            }
+        }
+
         if (loginGo) {
             await this.ensureRefreshToken();
             await this.login();

--- a/main.js
+++ b/main.js
@@ -366,6 +366,11 @@ class Bluelink extends utils.Adapter {
         adapterObj.native.tokenExpiry = expiresAt;
         adapterObj.native.tokenType = extra.cci ? 'cci' : 'legacy';
         adapterObj.native.lastTokenSaveAt = Date.now();
+        // tokenExpiry isn't a real server-provided expiry (Hyundai doesn't document one) -
+        // it's just our own +180-day scheduling placeholder for ensureRefreshToken()'s
+        // proactive-renewal check. Track the real save time separately so the admin UI can
+        // show something honest instead of a made-up "valid until" date.
+        adapterObj.native.lastLoginDisplay = new Date().toISOString();
         if (extra.cci) {
             adapterObj.native.cciTokenSet = this.encrypt(JSON.stringify(extra.cci));
         }

--- a/main.js
+++ b/main.js
@@ -706,15 +706,23 @@ class Bluelink extends utils.Adapter {
             await this.readStatusVin(vehicle, force_update_obj.val);
         }
 
-        // Check token expiry once per day (not on every poll cycle)
+        // Check token expiry once per day (not on every poll cycle). For CCI accounts
+        // this MUST be gated on the persisted lastTokenSaveAt, not the in-memory
+        // _lastTokenCheck: that resets to 0 on every restart, and since the CCI token
+        // rotates on every single refresh (see prepareCciSession()/makeCciRefresher()),
+        // gating on it made this fire on every restart instead of once a day - each
+        // firing found a "changed" token, persisted it, and restarted again, an
+        // infinite loop (confirmed live against a real account, js-controller's
+        // crash-loop protection had to disable the instance).
         const now = Date.now();
-        if (now - this._lastTokenCheck > 24 * 60 * 60 * 1000) {
-            this._lastTokenCheck = now;
-            if (this.config.tokenType === 'cci') {
+        if (this.config.tokenType === 'cci') {
+            const sinceLastSave = now - (Number(this.config.lastTokenSaveAt) || 0);
+            if (sinceLastSave > 24 * 60 * 60 * 1000) {
                 await this.persistRotatedCciTokenIfNeeded();
-            } else {
-                await this.ensureRefreshToken();
             }
+        } else if (now - this._lastTokenCheck > 24 * 60 * 60 * 1000) {
+            this._lastTokenCheck = now;
+            await this.ensureRefreshToken();
         }
 
         //set ne cycle


### PR DESCRIPTION
## Summary
Hotfix for a regression in #354 / v3.1.32, reported live against a real Hyundai Ioniq5 account (forum: [post #2471](https://forum.iobroker.net/topic/43592/adapter-hyundai-bluelink-oder-kia-uvo/2471) and a follow-up debug-level log from that user).

**Note:** This does not occur on my own account/instance - I don't run into this restart pattern myself. The core fix below is based entirely on analyzing the reporting user's debug-level log plus reading the relevant code path, not on reproducing the bug live myself. See "Live confirmation" below though - it has since been verified working.

The daily CCI-token-persistence check (`persistRotatedCciTokenIfNeeded()`, added in #354) was gated on `this._lastTokenCheck`, an **in-memory** instance property that resets to `0` on every adapter restart. Since the CCI token rotates on every single refresh (`prepareCciSession()`/`makeCciRefresher()`), gating on it made the "once a day" check fire on **every restart** instead of once a day:

1. Adapter restarts, refreshes the CCI token (rotates it)
2. `_lastTokenCheck` is `0` → "24h since last check" check passes immediately
3. Finds the freshly-rotated token differs from what's on disk → persists it → this triggers another restart
4. Repeat

The reporting user's debug log shows this precisely: after the initial (legitimate) full-login save, three consecutive restarts each show a clean, error-free `CCI refresh: CCI token set refreshed` immediately followed by another `[saveTokenToConfig]` and restart - with no error or warning logged in between. 4 restarts in ~90 seconds total, until js-controller's own crash-loop protection disabled the instance.

## Fix
Gate the CCI branch of this check on the already-persisted `native.lastTokenSaveAt` instead (the same field `saveTokenToConfig()` already sets unconditionally on every real save). This survives restarts, so the check now genuinely fires at most once per real 24h, regardless of restart frequency. Legacy-mode's existing `_lastTokenCheck`-gated `ensureRefreshToken()` call is untouched - it's harmless there since `ensureRefreshToken()` itself checks the persisted `tokenExpiry` and is a no-op most of the time regardless of how often it's invoked.

## Also included: honest "last login" admin display instead of a guessed expiry date
The admin config showed a "Refresh token valid until" date computed as `now + 180 days` at save time - a value we invented ourselves, not something Hyundai's API actually returns (the real CCI refresh-token lifetime isn't documented anywhere). This was actively misleading: while debugging the issue above, the reporting user's token died after only ~13 hours of the adapter being offline, despite the admin showing "valid" for months. Replaced it with `lastLoginDisplay`, which just shows the timestamp of the last real successful login/save - no guessing. Existing installs get it backfilled once from the already-tracked `lastTokenSaveAt` on their first start with this update, so it isn't blank until the next save.

## Live confirmation
The reporting user has since updated and confirmed: after the one expected fallback restart (stale token from being offline → full login), the adapter now stays up without repeating - no more restart loop.

## Test plan
- [x] `npm run lint` / `npm run check` clean
- [x] Root-caused directly from a real user's debug-level log (see forum thread) - the exact restart-loop sequence and its cause are fully visible in the log, not just inferred
- [x] Live-confirmed by the reporting user after updating - loop is gone, stays up after the one expected fallback restart
